### PR TITLE
chore: changed image generation response format to url

### DIFF
--- a/backend/open_webui/apps/images/main.py
+++ b/backend/open_webui/apps/images/main.py
@@ -466,8 +466,7 @@ async def image_generations(
                 "n": form_data.n,
                 "size": (
                     form_data.size if form_data.size else app.state.config.IMAGE_SIZE
-                ),
-                "response_format": "b64_json",
+                )
             }
 
             # Use asyncio.to_thread for the requests.post call
@@ -484,7 +483,7 @@ async def image_generations(
             images = []
 
             for image in res["data"]:
-                image_filename = save_b64_image(image["b64_json"])
+                image_filename = save_url_image(image["url"])
                 images.append({"url": f"/cache/image/generations/{image_filename}"})
                 file_body_path = IMAGE_CACHE_DIR.joinpath(f"{image_filename}.json")
 


### PR DESCRIPTION
Mistral.rs only support responding with an URL to the image(s) generated